### PR TITLE
This shouldn't be necessary, it's a dep of AAGIThemes

### DIFF
--- a/inst/rmarkdown/templates/AAGI_short_report/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/AAGI_short_report/skeleton/skeleton.Rmd
@@ -74,11 +74,6 @@ if (!require(AAGIThemes)) {
     "AAGI-AUS/AAGIThemes", dependencies = TRUE, upgrade = FALSE
   )
 }
-if (!require(AAGIPalettes)) {
-  remotes::install_github(
-    "AAGI-AUS/AAGIPalettes", dependencies = TRUE, upgrade = FALSE
-  )
-}
 library(AAGIThemes)
 library(AAGIPalettes)
 ```


### PR DESCRIPTION
shouldn't need to install{AAGIPalettes}, it should already be installed with {AAGIThemes}